### PR TITLE
feat: add verification support via mock expect

### DIFF
--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -123,6 +123,7 @@ impl From<Cli> for Config {
         Self {
             port: cli.port,
             verbose: Some(true),
+            verify: Some(false),
             global_delay: cli.global_delay_milliseconds(),
             latency: cli.latency_milliseconds(),
         }

--- a/lib/src/model/mod.rs
+++ b/lib/src/model/mod.rs
@@ -1,4 +1,8 @@
-use std::{fs::OpenOptions, path::PathBuf};
+use std::{
+    fs::OpenOptions,
+    hash::{Hash, Hasher},
+    path::PathBuf,
+};
 
 use serde::{Deserialize, Serialize};
 use wiremock::{Mock, MockBuilder, Respond, ResponseTemplate};
@@ -11,7 +15,7 @@ use crate::Config;
 pub mod request;
 pub mod response;
 
-#[derive(Serialize, Deserialize, Debug, Hash)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JsonStub {
     #[serde(skip_serializing)]
     pub id: Option<String>,
@@ -72,5 +76,21 @@ impl Default for JsonStub {
             request: RequestStub::default(),
             response: ResponseStub::default(),
         }
+    }
+}
+
+impl Hash for JsonStub {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if let Some(it) = self.id.as_ref() {
+            it.hash(state);
+        }
+        if let Some(it) = self.uuid.as_ref() {
+            it.hash(state);
+        }
+        if let Some(it) = self.priority.as_ref() {
+            it.hash(state);
+        }
+        self.request.hash(state);
+        self.response.hash(state);
     }
 }

--- a/lib/src/record/mapping/mod.rs
+++ b/lib/src/record/mapping/mod.rs
@@ -11,6 +11,7 @@ impl From<RecordInput<'_>> for JsonStub {
             id: None,
             uuid: None,
             priority: None,
+            expect: None,
             request: RequestStub::from((&mut *ex, cfg)),
             response: ResponseStub::from((&mut *ex, cfg)),
         }

--- a/lib/src/server/config.rs
+++ b/lib/src/server/config.rs
@@ -5,6 +5,8 @@ pub struct Config {
     pub port: Option<u16>,
     /// Enables turning off logs
     pub verbose: Option<bool>,
+    /// Enables verification via https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect
+    pub verify: Option<bool>,
     /// Global delay in milliseconds.
     /// Supersedes any locally defined delay
     pub global_delay: Option<u64>,

--- a/lib/tests/misc/config_verify.rs
+++ b/lib/tests/misc/config_verify.rs
@@ -6,7 +6,7 @@ use stubr::Config;
 use crate::utils::*;
 
 #[async_std::test]
-async fn should_verify_that_no_request_is_made_success() {
+async fn should_succeed_when_no_request_made_and_none_expected() {
     let cfg = Config {
         verify: Some(true),
         ..Default::default()
@@ -16,7 +16,7 @@ async fn should_verify_that_no_request_is_made_success() {
 
 #[async_std::test]
 #[should_panic]
-async fn should_verify_that_no_request_is_made_panic() {
+async fn should_fail_when_a_request_is_made_but_none_expected() {
     let cfg = Config {
         verify: Some(true),
         ..Default::default()
@@ -26,33 +26,14 @@ async fn should_verify_that_no_request_is_made_panic() {
 }
 
 #[async_std::test]
+#[stubr::mock(full_path = "tests/stubs/resp/verify/expect-1.json", verify = true)]
 #[should_panic]
-async fn should_verify_that_a_request_is_made_panic() {
-    let cfg = Config {
-        verify: Some(true),
-        ..Default::default()
-    };
-    let _srv = Stubr::start_with("tests/stubs/resp/verify/expect-1.json", cfg).await;
+async fn should_fail_when_no_request_is_made_but_1_expected() {
+    // no request made
 }
 
 #[async_std::test]
-#[should_panic]
-async fn should_verify_that_two_requests_are_made_panic() {
-    let cfg = Config {
-        verify: Some(true),
-        ..Default::default()
-    };
-    let srv = Stubr::start_with("tests/stubs/resp/verify/expect-2.json", cfg).await;
-    get(&srv.uri()).await.expect_status_ok();
-}
-
-#[async_std::test]
-async fn should_verify_that_two_requests_are_made_success() {
-    let cfg = Config {
-        verify: Some(true),
-        ..Default::default()
-    };
-    let srv = Stubr::start_with("tests/stubs/resp/verify/expect-2.json", cfg).await;
-    get(&srv.uri()).await.expect_status_ok();
-    get(&srv.uri()).await.expect_status_ok();
+#[stubr::mock(full_path = "tests/stubs/resp/verify/expect-1.json", verify = true)]
+async fn should_succeed_when_1_request_made_and_1_expected() {
+    get(&stubr.uri()).await.expect_status_ok();
 }

--- a/lib/tests/misc/config_verify.rs
+++ b/lib/tests/misc/config_verify.rs
@@ -1,0 +1,58 @@
+use asserhttp::*;
+use surf::get;
+
+use stubr::Config;
+
+use crate::utils::*;
+
+#[async_std::test]
+async fn should_verify_that_no_request_is_made_success() {
+    let cfg = Config {
+        verify: Some(true),
+        ..Default::default()
+    };
+    let _srv = Stubr::start_with("tests/stubs/resp/verify/expect-0.json", cfg).await;
+}
+
+#[async_std::test]
+#[should_panic]
+async fn should_verify_that_no_request_is_made_panic() {
+    let cfg = Config {
+        verify: Some(true),
+        ..Default::default()
+    };
+    let srv = Stubr::start_with("tests/stubs/resp/verify/expect-0.json", cfg).await;
+    get(&srv.uri()).await.expect_status_ok();
+}
+
+#[async_std::test]
+#[should_panic]
+async fn should_verify_that_a_request_is_made_panic() {
+    let cfg = Config {
+        verify: Some(true),
+        ..Default::default()
+    };
+    let _srv = Stubr::start_with("tests/stubs/resp/verify/expect-1.json", cfg).await;
+}
+
+#[async_std::test]
+#[should_panic]
+async fn should_verify_that_two_requests_are_made_panic() {
+    let cfg = Config {
+        verify: Some(true),
+        ..Default::default()
+    };
+    let srv = Stubr::start_with("tests/stubs/resp/verify/expect-2.json", cfg).await;
+    get(&srv.uri()).await.expect_status_ok();
+}
+
+#[async_std::test]
+async fn should_verify_that_two_requests_are_made_success() {
+    let cfg = Config {
+        verify: Some(true),
+        ..Default::default()
+    };
+    let srv = Stubr::start_with("tests/stubs/resp/verify/expect-2.json", cfg).await;
+    get(&srv.uri()).await.expect_status_ok();
+    get(&srv.uri()).await.expect_status_ok();
+}

--- a/lib/tests/misc/mod.rs
+++ b/lib/tests/misc/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod config;
 pub mod config_delay;
+pub mod config_verify;
 pub mod opentracing;
 pub mod probes;
 pub mod pub_api;

--- a/lib/tests/stubs/resp/verify/expect-0.json
+++ b/lib/tests/stubs/resp/verify/expect-0.json
@@ -1,0 +1,9 @@
+{
+  "expect": 0,
+  "request": {
+    "method": "GET"
+  },
+  "response": {
+    "status": 200
+  }
+}

--- a/lib/tests/stubs/resp/verify/expect-1.json
+++ b/lib/tests/stubs/resp/verify/expect-1.json
@@ -1,0 +1,9 @@
+{
+  "expect": 1,
+  "request": {
+    "method": "GET"
+  },
+  "response": {
+    "status": 200
+  }
+}

--- a/lib/tests/stubs/resp/verify/expect-2.json
+++ b/lib/tests/stubs/resp/verify/expect-2.json
@@ -1,0 +1,9 @@
+{
+  "expect": 2,
+  "request": {
+    "method": "GET"
+  },
+  "response": {
+    "status": 200
+  }
+}

--- a/schemas/stubr.schema.json
+++ b/schemas/stubr.schema.json
@@ -20,6 +20,12 @@
       "maximum": 255,
       "minimum": 1
     },
+    "expect": {
+      "description": "Set an expectation on the number of times this stub should match.",
+      "type": "integer",
+      "maximum": 255,
+      "minimum": 0
+    },
     "request": {
       "description": "Request matching",
       "type": "object",


### PR DESCRIPTION
Adds the possibility to verify that a request has been handled by the mock server.

I've added some basic tests not sure if that's enough

Closes https://github.com/beltram/stubr/issues/426